### PR TITLE
[VIDEO-1728] Seekable s3sink

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('amazon-s3-gst-plugin', 'c', 'cpp',
-  version : '0.1.0',
+  version : '0.2.0',
   default_options : [ 'warning_level=2',
                       'buildtype=debugoptimized' ])
 

--- a/src/gstawsapihandle.cpp
+++ b/src/gstawsapihandle.cpp
@@ -1,0 +1,122 @@
+/* amazon-s3-gst-plugin
+ * Copyright (C) 2021 Laerdal Labs, DC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstawsapihandle.hpp"
+
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/logging/AWSLogging.h>
+#include <aws/core/utils/logging/LogSystemInterface.h>
+
+#include <gst/gst.h>
+
+GST_DEBUG_CATEGORY_EXTERN(gst_aws_s3_debug);
+
+namespace gst {
+namespace aws {
+
+class Logger : public Aws::Utils::Logging::LogSystemInterface
+{
+public:
+    Aws::Utils::Logging::LogLevel GetLogLevel(void) const override
+    {
+        return _to_aws_log_level(gst_debug_category_get_threshold(gst_aws_s3_debug));
+    }
+
+    void Log(Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format, ...) override
+    {
+        GstDebugLevel level = _to_gst_log_level(log_level);
+        va_list varargs;
+        va_start (varargs, format);
+
+        if (G_UNLIKELY ((level) <= GST_LEVEL_MAX && (level) <= _gst_debug_min))
+        {
+            gst_debug_log_valist(gst_aws_s3_debug, level, "", tag, 0, NULL, format, varargs);
+        }
+        va_end (varargs);
+    }
+
+    void LogStream(Aws::Utils::Logging::LogLevel log_level, const char* tag, const Aws::OStringStream &message_stream) override
+    {
+        Log(log_level, tag, "%s", message_stream.str().c_str());
+    }
+
+    void Flush() override
+    {
+    }
+
+private:
+    static Aws::Utils::Logging::LogLevel _to_aws_log_level(GstDebugLevel level)
+    {
+        using Aws::Utils::Logging::LogLevel;
+        switch (level)
+        {
+            case GST_LEVEL_NONE: return LogLevel::Off;
+            case GST_LEVEL_ERROR: return LogLevel::Error;
+            case GST_LEVEL_WARNING: return LogLevel::Warn;
+            case GST_LEVEL_FIXME:
+            case GST_LEVEL_INFO: return LogLevel::Info;
+            case GST_LEVEL_DEBUG: return LogLevel::Debug;
+            default: return LogLevel::Trace;
+        }
+    }
+
+    static GstDebugLevel _to_gst_log_level(Aws::Utils::Logging::LogLevel level)
+    {
+        using Aws::Utils::Logging::LogLevel;
+        switch (level)
+        {
+            case LogLevel::Off: return GST_LEVEL_NONE;
+            case LogLevel::Fatal:
+            case LogLevel::Error: return GST_LEVEL_ERROR;
+            case LogLevel::Warn: return GST_LEVEL_WARNING;
+            case LogLevel::Info: return GST_LEVEL_INFO;
+            case LogLevel::Debug: return GST_LEVEL_DEBUG;
+            default: return GST_LEVEL_TRACE;
+        }
+    }
+};
+} // namespace aws
+} // namespace s3
+
+using gst::aws::ApiHandle;
+ApiHandle::ApiHandle() {
+    Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<Logger>());
+    Aws::SDKOptions options;
+    Aws::InitAPI(options);
+}
+
+ApiHandle::~ApiHandle()
+{
+    Aws::ShutdownAPI(Aws::SDKOptions {});
+    Aws::Utils::Logging::ShutdownAWSLogging();
+}
+
+
+std::shared_ptr<ApiHandle> ApiHandle::GetHandle()
+{
+    static std::weak_ptr<ApiHandle> instance;
+    if (auto ptr = instance.lock()) {
+        return ptr;
+    }
+
+    std::shared_ptr<ApiHandle> ptr(new ApiHandle());
+    instance = ptr;
+    return ptr;
+}

--- a/src/gstawsapihandle.hpp
+++ b/src/gstawsapihandle.hpp
@@ -1,5 +1,5 @@
 /* amazon-s3-gst-plugin
- * Copyright (C) 2019 Amazon <mkolny@amazon.com>
+ * Copyright (C) 2021 Laerdal Labs, DC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -16,30 +16,29 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301, USA.
  */
+#ifndef __AWS_API__
+#define __AWS_API__
 
-#include "config.h"
+#include <memory>
 
-#include <gst/gst.h>
+namespace gst {
+namespace aws {
 
-#include "gsts3sink.h"
-
-GST_DEBUG_CATEGORY(gst_aws_s3_debug);
-
-static gboolean
-plugin_init (GstPlugin * plugin)
+class ApiHandle
 {
-  if (!gst_element_register (plugin, "s3sink", GST_RANK_NONE,
-          gst_s3_sink_get_type ()))
-    return FALSE;
+    public:
+        static std::shared_ptr<ApiHandle> GetHandle();
+        virtual ~ApiHandle();
 
-  GST_DEBUG_CATEGORY_INIT(gst_aws_s3_debug, "aws-s3", 0, "AWS S3");
+    protected:
+        ApiHandle();
 
-  return TRUE;
-}
+    private:
+        ApiHandle(const ApiHandle&) = delete;
+        ApiHandle& operator=(const ApiHandle&) = delete;
+};
 
-GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
-    GST_VERSION_MINOR,
-    s3elements,
-    "Amazon S3 elements",
-    plugin_init,
-    VERSION, "LGPL", "GStreamer S3 package", "https://www.amazon.com")
+} // namespace aws
+} // namespace gst
+
+#endif /* __AWS_API__ */

--- a/src/gstawscredentials.cpp
+++ b/src/gstawscredentials.cpp
@@ -18,6 +18,8 @@
  */
 #include "gstawscredentials.hpp"
 
+#include "gstawsutils.hpp"
+
 #include <gst/gst.h>
 
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
@@ -74,12 +76,6 @@ static bool
 strings_equal(const gchar* str1, const gchar* str2, size_t len2)
 {
 	return strlen(str1) == len2 && strncmp(str1, str2, len2) == 0;
-}
-
-static bool
-is_null_or_empty(const char* str)
-{
-  return str == NULL || strcmp(str, "") == 0;
 }
 
 static std::unique_ptr<AWSCredentialsProvider>

--- a/src/gstawsutils.cpp
+++ b/src/gstawsutils.cpp
@@ -1,0 +1,43 @@
+/* amazon-s3-gst-plugin
+ * Copyright (C) 2021 Laerdal Labs, DC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstawsutils.hpp"
+
+#include <aws/s3/model/GetBucketLocationRequest.h>
+#include <aws/s3/model/GetBucketLocationResult.h>
+#include <aws/s3/S3Client.h>
+
+bool get_bucket_location(const char* bucket_name, const Aws::Client::ClientConfiguration& client_config, Aws::String& location)
+{
+  Aws::S3::S3Client client(client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+
+  auto outcome = client.GetBucketLocation(Aws::S3::Model::GetBucketLocationRequest().WithBucket(bucket_name));
+  if (!outcome.IsSuccess())
+  {
+    return false;
+  }
+
+  location = Aws::S3::Model::BucketLocationConstraintMapper::GetNameForBucketLocationConstraint(outcome.GetResult().GetLocationConstraint());
+  return true;
+}
+
+bool is_null_or_empty(const char* str)
+{
+  return str == nullptr || strcmp(str, "") == 0;
+}

--- a/src/gstawsutils.hpp
+++ b/src/gstawsutils.hpp
@@ -1,0 +1,31 @@
+/* amazon-s3-gst-plugin
+ * Copyright (C) 2021 Laerdal Labs, DC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_AWS_UTILS_HPP__
+#define __GST_AWS_UTILS_HPP__
+
+#include <aws/core/client/ClientConfiguration.h>
+
+bool get_bucket_location   (const char* bucket_name,
+                            const Aws::Client::ClientConfiguration& client_config,
+                            Aws::String& location);
+
+bool is_null_or_empty  (const char* str);
+
+#endif // __GST_AWS_UTILS_HPP__

--- a/src/gsts3downloader.cpp
+++ b/src/gsts3downloader.cpp
@@ -18,37 +18,14 @@
  */
 #include "gsts3downloader.h"
 
+#include "gstawsutils.hpp"
 #include "gstawsapihandle.hpp"
 #include "gstawscredentials.hpp"
-
-#include <aws/s3/model/GetBucketLocationRequest.h>
-#include <aws/s3/model/GetBucketLocationResult.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/GetObjectResult.h>
 #include <aws/s3/S3Client.h>
 
 #include <gst/gst.h>
-
-//TODO: move to re-use w/ uploader
-static bool get_bucket_location(const char* bucket_name, const Aws::Client::ClientConfiguration& client_config, Aws::String& location)
-{
-  Aws::S3::S3Client client(client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
-
-  auto outcome = client.GetBucketLocation(Aws::S3::Model::GetBucketLocationRequest().WithBucket(bucket_name));
-  if (!outcome.IsSuccess())
-  {
-    return false;
-  }
-
-  location = Aws::S3::Model::BucketLocationConstraintMapper::GetNameForBucketLocationConstraint(outcome.GetResult().GetLocationConstraint());
-  return true;
-}
-
-//TODO: move to re-use w/ uploader
-static bool is_null_or_empty(const char* str)
-{
-  return str == nullptr || strcmp(str, "") == 0;
-}
 
 struct _GstS3Downloader {
   _GstS3Downloader(const GstS3UploaderConfig *config);

--- a/src/gsts3downloader.cpp
+++ b/src/gsts3downloader.cpp
@@ -1,0 +1,174 @@
+/* amazon-s3-gst-plugin
+ * Copyright (C) 2021 Laerdal Labs, DC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#include "gsts3downloader.h"
+
+#include "gstawsapihandle.hpp"
+#include "gstawscredentials.hpp"
+
+#include <aws/s3/model/GetBucketLocationRequest.h>
+#include <aws/s3/model/GetBucketLocationResult.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/GetObjectResult.h>
+#include <aws/s3/S3Client.h>
+
+#include <gst/gst.h>
+
+//TODO: move to re-use w/ uploader
+static bool get_bucket_location(const char* bucket_name, const Aws::Client::ClientConfiguration& client_config, Aws::String& location)
+{
+  Aws::S3::S3Client client(client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+
+  auto outcome = client.GetBucketLocation(Aws::S3::Model::GetBucketLocationRequest().WithBucket(bucket_name));
+  if (!outcome.IsSuccess())
+  {
+    return false;
+  }
+
+  location = Aws::S3::Model::BucketLocationConstraintMapper::GetNameForBucketLocationConstraint(outcome.GetResult().GetLocationConstraint());
+  return true;
+}
+
+//TODO: move to re-use w/ uploader
+static bool is_null_or_empty(const char* str)
+{
+  return str == nullptr || strcmp(str, "") == 0;
+}
+
+struct _GstS3Downloader {
+  _GstS3Downloader(const GstS3UploaderConfig *config);
+
+  bool _init_downloader(const GstS3UploaderConfig *config);
+
+  size_t download_part(char * buffer, size_t first, size_t last);
+
+  Aws::String _bucket;
+  Aws::String _key;
+
+  std::shared_ptr<gst::aws::ApiHandle> _api_handle;
+  std::unique_ptr<Aws::S3::S3Client> _s3_client;
+};
+
+_GstS3Downloader::_GstS3Downloader(const GstS3UploaderConfig *config) :
+    _bucket(config->bucket),
+    _key(config->key),
+    _api_handle(config->init_aws_sdk ? gst::aws::ApiHandle::GetHandle() : nullptr)
+{
+}
+
+bool _GstS3Downloader::_init_downloader(const GstS3UploaderConfig *config)
+{
+  Aws::Client::ClientConfiguration client_config;
+  if (!is_null_or_empty(config->ca_file))
+  {
+    client_config.caFile = config->ca_file;
+  }
+  if (is_null_or_empty(config->region))
+  {
+    Aws::String region;
+    if (!get_bucket_location(config->bucket, client_config, region))
+    {
+      // TODO report warning
+    }
+    else if (!region.empty())
+    {
+      client_config.region = std::move(region);
+    }
+  }
+  else
+  {
+    client_config.region = config->region;
+  }
+
+  auto credentials_provider = gst_aws_credentials_create_provider(config->credentials);
+  if (!credentials_provider)
+  {
+    return false;
+  }
+
+  // Configure AWS SDK specific client configuration
+  if (!is_null_or_empty(config->aws_sdk_endpoint))
+  {
+    client_config.endpointOverride = Aws::String(config->aws_sdk_endpoint);
+  }
+  if (config->aws_sdk_use_http)
+  {
+    client_config.scheme = Aws::Http::Scheme::HTTP;
+  }
+  client_config.verifySSL = config->aws_sdk_verify_ssl;
+
+  _s3_client = config->aws_sdk_s3_sign_payload ?
+    std::unique_ptr<Aws::S3::S3Client>(new Aws::S3::S3Client(std::move(credentials_provider), client_config)) :
+    std::unique_ptr<Aws::S3::S3Client>(new Aws::S3::S3Client(std::move(credentials_provider), client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false));
+
+  return true;
+}
+
+size_t
+_GstS3Downloader::download_part(char* buffer, size_t first, size_t last)
+{
+  char *range = g_strdup_printf("bytes=%ld-%ld", first, last);
+
+  Aws::S3::Model::GetObjectRequest request;
+  request.WithBucket(_bucket)
+    .WithKey(_key)
+    .WithRange(range);
+
+  g_free(range);
+
+
+  auto outcome = _s3_client->GetObject(request);
+
+  if (!outcome.IsSuccess()) {
+    return 0;
+  }
+
+  return outcome.GetResult()
+    .GetBody()
+    .read(buffer, last-first)
+    .gcount();
+}
+
+GstS3Downloader *
+gst_s3_downloader_new (const GstS3UploaderConfig * config)
+{
+  g_return_val_if_fail (config, NULL);
+
+  auto impl = new _GstS3Downloader(config);
+
+  if (!impl->_init_downloader(config))
+  {
+    delete impl;
+    return NULL;
+  }
+
+  return impl;
+}
+
+void
+gst_s3_downloader_free (GstS3Downloader * downloader)
+{
+  delete reinterpret_cast<_GstS3Downloader *>(downloader);
+}
+
+gsize
+gst_s3_downloader_download_part (GstS3Downloader * downloader,
+    gchar * buffer, gsize first, gsize last)
+{
+  return reinterpret_cast<_GstS3Downloader *>(downloader)->download_part(buffer, first, last);
+}

--- a/src/gsts3downloader.h
+++ b/src/gsts3downloader.h
@@ -1,5 +1,5 @@
 /* amazon-s3-gst-plugin
- * Copyright (C) 2019 Amazon <mkolny@amazon.com>
+ * Copyright (C) 2021 Laerdal Labs, DC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -16,30 +16,29 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301, USA.
  */
+#ifndef __GST_S3_DOWNLOADER_H__
+#define __GST_S3_DOWNLOADER_H__
 
-#include "config.h"
+#include <glib.h>
 
-#include <gst/gst.h>
+#include "gsts3uploaderconfig.h"
 
-#include "gsts3sink.h"
+G_BEGIN_DECLS
 
-GST_DEBUG_CATEGORY(gst_aws_s3_debug);
+typedef struct _GstS3Downloader GstS3Downloader;
 
-static gboolean
-plugin_init (GstPlugin * plugin)
-{
-  if (!gst_element_register (plugin, "s3sink", GST_RANK_NONE,
-          gst_s3_sink_get_type ()))
-    return FALSE;
+GstS3Downloader *gst_s3_downloader_new (const GstS3UploaderConfig * config);
 
-  GST_DEBUG_CATEGORY_INIT(gst_aws_s3_debug, "aws-s3", 0, "AWS S3");
+void gst_s3_downloader_free (GstS3Downloader * downloader);
 
-  return TRUE;
-}
+gsize gst_s3_downloader_download_part (GstS3Downloader *
+    downloader, gchar * buffer, gsize first, gsize last);
 
-GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
-    GST_VERSION_MINOR,
-    s3elements,
-    "Amazon S3 elements",
-    plugin_init,
-    VERSION, "LGPL", "GStreamer S3 package", "https://www.amazon.com")
+GType gst_s3_downloader_get_type (void);
+
+#define GST_TYPE_AWS_S3_DOWNLOADER \
+  (gst_aws_downloader_get_type())
+
+G_END_DECLS
+
+#endif /* __GST_S3_DOWNLOADER_H__ */

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -20,13 +20,12 @@
 #include "gsts3multipartuploader.h"
 
 #include "gstawscredentials.hpp"
+#include "gstawsapihandle.hpp"
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/utils/HashingUtils.h>
-#include <aws/core/utils/logging/AWSLogging.h>
-#include <aws/core/utils/logging/LogSystemInterface.h>
 #include <aws/core/utils/ResourceManager.h>
 #include <aws/core/utils/stream/PreallocatedStreamBuf.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
@@ -34,13 +33,12 @@
 #include <aws/s3/model/GetBucketLocationRequest.h>
 #include <aws/s3/model/GetBucketLocationResult.h>
 #include <aws/s3/model/UploadPartRequest.h>
+#include <aws/s3/model/UploadPartCopyRequest.h>
 #include <aws/s3/S3Client.h>
 #include <aws/sts/model/AssumeRoleRequest.h>
 #include <aws/sts/STSClient.h>
 
 #include <gst/gst.h>
-
-GST_DEBUG_CATEGORY_EXTERN(gst_s3_sink_debug);
 
 namespace gst
 {
@@ -48,98 +46,6 @@ namespace aws
 {
 namespace s3
 {
-class Logger : public Aws::Utils::Logging::LogSystemInterface
-{
-public:
-    Aws::Utils::Logging::LogLevel GetLogLevel(void) const override
-    {
-        return _to_aws_log_level(gst_debug_category_get_threshold(gst_s3_sink_debug));
-    }
-
-    void Log(Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format, ...) override
-    {
-        GstDebugLevel level = _to_gst_log_level(log_level);
-        va_list varargs;
-        va_start (varargs, format);
-
-        if (G_UNLIKELY ((level) <= GST_LEVEL_MAX && (level) <= _gst_debug_min))
-        {
-            gst_debug_log_valist(gst_s3_sink_debug, level, "", tag, 0, NULL, format, varargs);
-        }
-        va_end (varargs);
-    }
-
-    void LogStream(Aws::Utils::Logging::LogLevel log_level, const char* tag, const Aws::OStringStream &message_stream) override
-    {
-        Log(log_level, tag, "%s", message_stream.str().c_str());
-    }
-
-    void Flush() override
-    {
-    }
-
-private:
-    static Aws::Utils::Logging::LogLevel _to_aws_log_level(GstDebugLevel level)
-    {
-        using Aws::Utils::Logging::LogLevel;
-        switch (level)
-        {
-            case GST_LEVEL_NONE: return LogLevel::Off;
-            case GST_LEVEL_ERROR: return LogLevel::Error;
-            case GST_LEVEL_WARNING: return LogLevel::Warn;
-            case GST_LEVEL_FIXME:
-            case GST_LEVEL_INFO: return LogLevel::Info;
-            case GST_LEVEL_DEBUG: return LogLevel::Debug;
-            default: return LogLevel::Trace;
-        }
-    }
-
-    static GstDebugLevel _to_gst_log_level(Aws::Utils::Logging::LogLevel level)
-    {
-        using Aws::Utils::Logging::LogLevel;
-        switch (level)
-        {
-            case LogLevel::Off: return GST_LEVEL_NONE;
-            case LogLevel::Fatal:
-            case LogLevel::Error: return GST_LEVEL_ERROR;
-            case LogLevel::Warn: return GST_LEVEL_WARNING;
-            case LogLevel::Info: return GST_LEVEL_INFO;
-            case LogLevel::Debug: return GST_LEVEL_DEBUG;
-            default: return GST_LEVEL_TRACE;
-        }
-    }
-};
-
-class AwsApiHandle
-{
-    public:
-        static std::shared_ptr<AwsApiHandle> GetHandle() {
-            static std::weak_ptr<AwsApiHandle> instance;
-            if (auto ptr = instance.lock()) {
-                return ptr;
-            }
-
-            std::shared_ptr<AwsApiHandle> ptr(new AwsApiHandle());
-            instance = ptr;
-            return ptr;
-        }
-
-        virtual ~AwsApiHandle() {
-            Aws::ShutdownAPI(Aws::SDKOptions {});
-            Aws::Utils::Logging::ShutdownAWSLogging();
-        }
-
-    protected:
-        AwsApiHandle() {
-            Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<Logger>());
-            Aws::SDKOptions options;
-            Aws::InitAPI(options);
-        }
-
-    private:
-        AwsApiHandle(const AwsApiHandle&) = delete;
-        AwsApiHandle& operator=(const AwsApiHandle&) = delete;
-};
 
 static bool get_bucket_location(const char* bucket_name, const Aws::Client::ClientConfiguration& client_config, Aws::String& location)
 {
@@ -196,6 +102,13 @@ public:
         return ss.str() == outcome.GetResult().GetETag();
     }
 
+    bool verify_upload_outcome(const Aws::S3::Model::UploadPartCopyOutcome& outcome) const
+    {
+        Aws::StringStream ss;
+        ss << "\"" << Aws::Utils::HashingUtils::HexEncode(_md5_hash) << "\"";
+        return ss.str() == outcome.GetResult().GetCopyPartResult().GetETag();
+    }
+
 private:
     Aws::Utils::ByteBuffer _md5_hash;
     Aws::String _etag;
@@ -249,7 +162,8 @@ public:
         return _parts_failed.size();
     }
 
-    bool verify_upload_outcome(int part_number, const Aws::S3::Model::UploadPartOutcome& outcome) const
+    template <typename T>
+    bool verify_upload_outcome(int part_number, const Aws::Utils::Outcome<T, Aws::S3::S3Error>& outcome) const
     {
         if (!_verify_hash)
         {
@@ -342,6 +256,7 @@ public:
     ~MultipartUploader();
 
     bool upload(const char* data, size_t size);
+    bool upload_copy(const char* bucket, const char *key, size_t first, size_t last);
     bool complete();
 
 private:
@@ -354,13 +269,15 @@ private:
 
     static void _handle_upload_completed(const Aws::S3::S3Client*, const Aws::S3::Model::UploadPartRequest&, const Aws::S3::Model::UploadPartOutcome& outcome, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& ctx);
 
+    static void _handle_upload_copy_completed(const Aws::S3::S3Client*, const Aws::S3::Model::UploadPartCopyRequest&, const Aws::S3::Model::UploadPartCopyOutcome& outcome, const std::shared_ptr<const Aws::Client::AsyncCallerContext>& ctx);
+
     Aws::String _bucket;
     Aws::String _key;
     Aws::S3::Model::ObjectCannedACL _acl;
 
     Aws::S3::Model::CreateMultipartUploadOutcome _upload_outcome;
 
-    std::shared_ptr<AwsApiHandle> _api_handle;
+    std::shared_ptr<ApiHandle> _api_handle;
     std::unique_ptr<Aws::S3::S3Client> _s3_client;
 
     std::condition_variable _upload_completed_cv;
@@ -386,7 +303,7 @@ private:
 MultipartUploader::MultipartUploader(const GstS3UploaderConfig *config) :
     _bucket(config->bucket),
     _key(config->key),
-    _api_handle(config->init_aws_sdk ? AwsApiHandle::GetHandle() : nullptr),
+    _api_handle(config->init_aws_sdk ? ApiHandle::GetHandle() : nullptr),
     _part_states(std::make_shared<PartStateCollection>(false))
 {
 }
@@ -523,6 +440,34 @@ bool MultipartUploader::upload(const char* data, size_t size)
     return true;
 }
 
+bool MultipartUploader::upload_copy(const char* bucket, const char *key, size_t first, size_t last)
+{
+    int part_number = ++_part_counter;
+    gchar *copy_source = g_strdup_printf("%s/%s", bucket, key);
+    gchar *copy_source_range = g_strdup_printf("bytes=%ld-%ld", first, last);
+
+    Aws::S3::Model::UploadPartCopyRequest request;
+    request.WithBucket(_bucket)
+        .WithKey(_key)
+        .WithPartNumber(part_number)
+        .WithUploadId(_upload_outcome.GetResult().GetUploadId())
+        .WithCopySource(copy_source)
+        .WithCopySourceRange(copy_source_range);
+
+    g_free(copy_source);
+    g_free(copy_source_range);
+
+    PartState part_state(part_number);
+
+    _part_states->start(std::move(part_state));
+
+    auto context = std::make_shared<MultipartUploaderContext>(_part_states, _buffer_manager, part_number);
+
+    _s3_client->UploadPartCopyAsync(request, _handle_upload_copy_completed, context);
+
+    return true;
+}
+
 bool MultipartUploader::complete()
 {
     _part_states->wait_for_complete();
@@ -573,6 +518,26 @@ void MultipartUploader::_handle_upload_completed(const Aws::S3::S3Client*,
     }
 }
 
+void MultipartUploader::_handle_upload_copy_completed(const Aws::S3::S3Client*,
+    G_GNUC_UNUSED const Aws::S3::Model::UploadPartCopyRequest& request,
+    const Aws::S3::Model::UploadPartCopyOutcome& outcome,
+    const std::shared_ptr<const Aws::Client::AsyncCallerContext>& ctx)
+{
+    auto context = std::static_pointer_cast<const MultipartUploaderContext>(ctx);
+
+    auto states = context->get_part_states();
+    int part_number = context->get_part_number();
+
+    if (outcome.IsSuccess() && states->verify_upload_outcome(part_number, outcome))
+    {
+        states->mark_part_as_completed(part_number, outcome.GetResult().GetCopyPartResult().GetETag());
+    }
+    else
+    {
+        states->mark_part_as_failed(part_number);
+    }
+}
+
 } // namespace s3
 } // namespace aws
 } // namespace gst
@@ -606,6 +571,16 @@ gst_s3_multipart_uploader_upload_part (GstS3Uploader *
 }
 
 static gboolean
+gst_s3_multipart_uploader_upload_part_copy (GstS3Uploader *
+    uploader, const gchar * bucket, const gchar * key, gsize first,
+    gsize last)
+{
+  GstS3MultipartUploader *self = MULTIPART_UPLOADER_ (uploader);
+  g_return_val_if_fail (self && self->impl, FALSE);
+  return self->impl->upload_copy (bucket, key, first, last);
+}
+
+static gboolean
 gst_s3_multipart_uploader_complete (GstS3Uploader * uploader)
 {
   GstS3MultipartUploader *self = MULTIPART_UPLOADER_ (uploader);
@@ -615,6 +590,7 @@ gst_s3_multipart_uploader_complete (GstS3Uploader * uploader)
 static GstS3UploaderClass default_class = {
   gst_s3_multipart_uploader_destroy,
   gst_s3_multipart_uploader_upload_part,
+  gst_s3_multipart_uploader_upload_part_copy,
   gst_s3_multipart_uploader_complete
 };
 

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -19,6 +19,7 @@
 
 #include "gsts3multipartuploader.h"
 
+#include "gstawsutils.hpp"
 #include "gstawscredentials.hpp"
 #include "gstawsapihandle.hpp"
 
@@ -46,25 +47,6 @@ namespace aws
 {
 namespace s3
 {
-
-static bool get_bucket_location(const char* bucket_name, const Aws::Client::ClientConfiguration& client_config, Aws::String& location)
-{
-    Aws::S3::S3Client client(client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
-
-    auto outcome = client.GetBucketLocation(Aws::S3::Model::GetBucketLocationRequest().WithBucket(bucket_name));
-    if (!outcome.IsSuccess())
-    {
-        return false;
-    }
-
-    location = Aws::S3::Model::BucketLocationConstraintMapper::GetNameForBucketLocationConstraint(outcome.GetResult().GetLocationConstraint());
-    return true;
-}
-
-static bool is_null_or_empty(const char* str)
-{
-    return str == nullptr || strcmp(str, "") == 0;
-}
 
 using BufferManager = Aws::Utils::ExclusiveOwnershipResourceManager<uint8_t*>;
 

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -89,6 +89,8 @@ static GstFlowReturn gst_s3_sink_render (GstBaseSink * sink,
     GstBuffer * buffer);
 static gboolean gst_s3_sink_query (GstBaseSink * bsink, GstQuery * query);
 
+static gboolean gst_s3_sink_do_flush (GstS3Sink * sink);
+static gboolean gst_s3_sink_do_seek (GstS3Sink * sink, guint64 new_offset);
 static gboolean gst_s3_sink_fill_buffer (GstS3Sink * sink, GstBuffer * buffer);
 static gboolean gst_s3_sink_flush_buffer (GstS3Sink * sink);
 
@@ -252,12 +254,21 @@ gst_s3_destroy_uploader (GstS3Sink * sink)
   }
 }
 
+static void gst_s3_destroy_downloader (GstS3Sink * sink)
+{
+  if (sink->downloader) {
+    gst_s3_downloader_free (sink->downloader);
+    sink->downloader = NULL;
+  }
+}
+
 static void
 gst_s3_sink_init (GstS3Sink * s3sink)
 {
   s3sink->config = GST_S3_UPLOADER_CONFIG_INIT;
   s3sink->config.credentials = gst_aws_credentials_new_default ();
   s3sink->uploader = NULL;
+  s3sink->downloader = NULL;
   s3sink->is_started = FALSE;
 
   gst_base_sink_set_sync (GST_BASE_SINK (s3sink), FALSE);
@@ -283,9 +294,10 @@ gst_s3_sink_dispose (GObject * object)
 {
   GstS3Sink *sink = GST_S3_SINK (object);
 
-  gst_s3_sink_release_config (&sink->config);
-
   gst_s3_destroy_uploader (sink);
+  gst_s3_destroy_downloader (sink);
+
+  gst_s3_sink_release_config (&sink->config);
 
   G_OBJECT_CLASS (parent_class)->dispose (object);
 }
@@ -485,6 +497,10 @@ gst_s3_sink_start (GstBaseSink * basesink)
     sink->uploader = gst_s3_multipart_uploader_new (&sink->config);
   }
 
+  if (sink->downloader == NULL) {
+    sink->downloader = gst_s3_downloader_new (&sink->config);
+  }
+
   if (!sink->uploader)
     goto init_failed;
 
@@ -492,8 +508,8 @@ gst_s3_sink_start (GstBaseSink * basesink)
   sink->buffer = NULL;
 
   sink->buffer = g_malloc (sink->config.buffer_size);
-  sink->current_buffer_size = 0;
-  sink->total_bytes_written = 0;
+  sink->buffer_size = sink->buffer_pos = 0;
+  sink->upload_size = sink->current_pos = 0;
 
   GST_DEBUG_OBJECT (sink, "started S3 upload %s %s",
       sink->config.bucket, sink->config.key);
@@ -513,6 +529,7 @@ no_destination:
 init_failed:
   {
     gst_s3_destroy_uploader (sink);
+    gst_s3_destroy_downloader (sink);
     GST_ELEMENT_ERROR (sink, RESOURCE, OPEN_WRITE,
         ("Unable to initialize S3 uploader."), (NULL));
     return FALSE;
@@ -525,17 +542,11 @@ gst_s3_sink_stop (GstBaseSink * basesink)
   GstS3Sink *sink = GST_S3_SINK (basesink);
   gboolean ret = TRUE;
 
+  gst_s3_sink_do_flush (sink);
   if (sink->buffer) {
-    gst_s3_sink_flush_buffer (sink);
-    ret = gst_s3_uploader_complete (sink->uploader);
-
     g_free (sink->buffer);
     sink->buffer = NULL;
-    sink->current_buffer_size = 0;
-    sink->total_bytes_written = 0;
   }
-
-  gst_s3_destroy_uploader (sink);
 
   sink->is_started = FALSE;
 
@@ -566,7 +577,7 @@ gst_s3_sink_query (GstBaseSink * base_sink, GstQuery * query)
         case GST_FORMAT_DEFAULT:
         case GST_FORMAT_BYTES:
           gst_query_set_position (query, GST_FORMAT_BYTES,
-              sink->total_bytes_written);
+              sink->current_pos);
           ret = TRUE;
           break;
         default:
@@ -579,7 +590,11 @@ gst_s3_sink_query (GstBaseSink * base_sink, GstQuery * query)
       GstFormat fmt;
 
       gst_query_parse_seeking (query, &fmt, NULL, NULL, NULL);
-      gst_query_set_seeking (query, fmt, FALSE, 0, -1);
+      if (fmt == GST_FORMAT_BYTES || fmt == GST_FORMAT_DEFAULT) {
+        gst_query_set_seeking (query, GST_FORMAT_BYTES, TRUE, 0, -1);
+      } else {
+        gst_query_set_seeking (query, fmt, FALSE, 0, -1);
+      }
       ret = TRUE;
       break;
     }
@@ -600,14 +615,43 @@ gst_s3_sink_event (GstBaseSink * base_sink, GstEvent * event)
   type = GST_EVENT_TYPE (event);
 
   switch (type) {
+    case GST_EVENT_SEGMENT:{
+      const GstSegment *segment;
+
+      gst_event_parse_segment (event, &segment);
+
+      if (segment->format == GST_FORMAT_BYTES) {
+        if (sink->current_pos != segment->start) {
+          if (!gst_s3_sink_do_seek(sink, segment->start))
+            goto seek_failed;
+        }
+      } else {
+        GST_WARNING_OBJECT (sink,
+            "Ignored SEGMENT event of format %u (%s)", (guint) segment->format,
+            gst_format_get_name (segment->format));
+      }
+      break;
+    }
+    case GST_EVENT_FLUSH_STOP:
+      //TODO: truncate to 0 bytes (is this necessary?)
+      break;
     case GST_EVENT_EOS:
-      gst_s3_sink_flush_buffer (sink);
+      gst_s3_sink_do_flush (sink);
       break;
     default:
       break;
   }
 
   return GST_BASE_SINK_CLASS (parent_class)->event (base_sink, event);
+
+  seek_failed:
+    {
+      GST_ELEMENT_ERROR (sink, RESOURCE, SEEK,
+          (("Error while seeking S3 Upload \"%s/%s\"."), sink->config.bucket, sink->config.key),
+          GST_ERROR_SYSTEM);
+      gst_event_unref (event);
+      return FALSE;
+    }
 }
 
 static GstFlowReturn
@@ -640,10 +684,11 @@ gst_s3_sink_flush_buffer (GstS3Sink * sink)
 {
   gboolean ret = TRUE;
 
-  if (sink->current_buffer_size) {
+  if (sink->buffer_size) {
+    GST_DEBUG_OBJECT(sink, "Uploading %ld byte part", sink->buffer_size);
     ret = gst_s3_uploader_upload_part (sink->uploader, sink->buffer,
-        sink->current_buffer_size);
-    sink->current_buffer_size = 0;
+        sink->buffer_size);
+    sink->buffer_pos = sink->buffer_size = 0;
   }
 
   return ret;
@@ -661,18 +706,20 @@ gst_s3_sink_fill_buffer (GstS3Sink * sink, GstBuffer * buffer)
 
   do {
     bytes_to_copy =
-        MIN (sink->config.buffer_size - sink->current_buffer_size,
+        MIN (sink->config.buffer_size - sink->buffer_pos,
         map_info.size - ptr);
-    memcpy (sink->buffer + sink->current_buffer_size, map_info.data + ptr,
+    memcpy (sink->buffer + sink->buffer_pos, map_info.data + ptr,
         bytes_to_copy);
-    sink->current_buffer_size += bytes_to_copy;
-    if (sink->current_buffer_size == sink->config.buffer_size) {
+    sink->buffer_pos += bytes_to_copy;
+    sink->buffer_size = MAX(sink->buffer_pos, sink->buffer_size);
+    if (sink->buffer_pos == sink->config.buffer_size) {
       if (!gst_s3_sink_flush_buffer (sink)) {
         return FALSE;
       }
     }
     ptr += bytes_to_copy;
-    sink->total_bytes_written += bytes_to_copy;
+    sink->current_pos += bytes_to_copy;
+    sink->upload_size = MAX(sink->upload_size, sink->current_pos);
   } while (ptr < map_info.size);
 
   gst_buffer_unmap (buffer, &map_info);
@@ -682,6 +729,181 @@ map_failed:
   {
     GST_ELEMENT_ERROR (sink, RESOURCE, NOT_FOUND,
         ("Failed to map the buffer."), (NULL));
+    return FALSE;
+  }
+}
+
+static gboolean
+gst_s3_sink_do_flush (GstS3Sink * sink)
+{
+  gsize bytes_remaining;
+  gboolean ret = TRUE;
+
+  if (sink->uploader && sink->buffer) {
+    GST_DEBUG_OBJECT (sink, "Flushing S3 Upload");
+
+    // Set current position to end of data in current buffer
+    const gsize buffer_start = sink->current_pos - sink->buffer_pos;
+    sink->buffer_pos = sink->buffer_size;
+    sink->current_pos = buffer_start + sink->buffer_pos;
+
+    if (sink->buffer_size != sink->config.buffer_size &&
+        sink->current_pos < sink->upload_size) {
+
+      const gsize bytes_to_read = MIN(sink->config.buffer_size - sink->buffer_size, sink->upload_size - sink->current_pos);
+      GST_TRACE_OBJECT(sink, "Post-filling %ld bytes, range: %ld-%ld", bytes_to_read, sink->current_pos,
+      sink->current_pos + bytes_to_read);
+
+      const gsize bytes_read = gst_s3_downloader_download_part(
+        sink->downloader,
+        sink->buffer + sink->buffer_pos,
+        sink->current_pos,
+        sink->current_pos + bytes_to_read);
+
+      sink->buffer_size += bytes_read;
+      sink->buffer_pos += bytes_read;
+      sink->current_pos += bytes_read;
+
+      if (bytes_to_read != bytes_read) {
+        GST_WARNING_OBJECT(sink, "Failed to post-fill %ld bytes, only read %ld", bytes_to_read, bytes_read);
+      }
+    }
+
+    gst_s3_sink_flush_buffer (sink);
+
+    bytes_remaining = sink->upload_size - sink->current_pos;
+    if (bytes_remaining) {
+      if (bytes_remaining < sink->config.buffer_size) {
+        GST_TRACE_OBJECT(sink, "Re-uploading remaining file from %ld to %ld", sink->current_pos, sink->upload_size);
+        const gsize bytes_read = gst_s3_downloader_download_part(
+          sink->downloader,
+          sink->buffer + sink->buffer_pos,
+          sink->current_pos,
+          sink->upload_size);
+
+        sink->buffer_size += bytes_read;
+        sink->buffer_pos += bytes_read;
+        sink->current_pos += bytes_read;
+
+        if (bytes_remaining != bytes_read) {
+          GST_WARNING_OBJECT(sink, "Failed to re-upload %ld bytes, only read %ld", bytes_remaining, bytes_read);
+        }
+
+        gst_s3_sink_flush_buffer (sink);
+      } else {
+        GST_TRACE_OBJECT(sink, "Copy-uploading remaining file from %ld to %ld", sink->current_pos, sink->upload_size);
+        gst_s3_uploader_upload_part_copy(
+          sink->uploader,
+          sink->config.bucket,
+          sink->config.key,
+          sink->current_pos,
+          sink->upload_size
+        );
+      }
+    }
+
+    ret = gst_s3_uploader_complete (sink->uploader);
+
+    sink->current_pos = sink->upload_size;
+  }
+
+  gst_s3_destroy_uploader (sink);
+
+  return ret;
+}
+
+static gboolean
+gst_s3_sink_do_seek (GstS3Sink * sink, guint64 new_offset)
+{
+  gsize bytes_to_zero;
+
+  GST_DEBUG_OBJECT(sink, "Seeking to new offset %" G_GUINT64_FORMAT " from %"
+      G_GUINT64_FORMAT " of %" G_GUINT64_FORMAT " total bytes", new_offset,
+      sink->current_pos, sink->upload_size);
+
+  const gsize buffer_start = sink->current_pos - sink->buffer_pos;
+  const gsize buffer_end = buffer_start + sink->config.buffer_size;
+  if (new_offset >= buffer_start && new_offset < buffer_end) {
+      GST_TRACE_OBJECT (sink, "Seeking to offset %" G_GUINT64_FORMAT
+          " which is within current buffer", new_offset);
+
+    sink->current_pos = MIN(buffer_start + sink->buffer_size, new_offset);
+    sink->buffer_pos = sink->current_pos - buffer_start;
+  }
+  else if (sink->current_pos != sink->upload_size || new_offset < sink->current_pos) {
+    gsize new_pos;
+
+    if (!gst_s3_sink_do_flush(sink))
+      goto flush_failed;
+
+    sink->uploader = gst_s3_multipart_uploader_new (&sink->config);
+
+    new_pos = MIN(new_offset, sink->upload_size);
+    if (new_pos >= sink->config.buffer_size) {
+      gboolean res;
+
+      GST_TRACE_OBJECT (sink, "Seeking to offset %" G_GUINT64_FORMAT
+          " using multipart upload copy", new_offset);
+      res = gst_s3_uploader_upload_part_copy(
+        sink->uploader,
+        sink->config.bucket,
+        sink->config.key,
+        0,
+        new_pos
+      );
+
+      if (!res) {
+        goto upload_copy_failed;
+      }
+
+      sink->current_pos = new_pos;
+    }
+    else if (new_pos > 0) {
+      GST_TRACE_OBJECT (sink, "Seeking to offset %" G_GUINT64_FORMAT
+          " by downloading", new_offset);
+
+      const gsize bytes_read = gst_s3_downloader_download_part(
+        sink->downloader,
+        sink->buffer,
+        0,
+        new_pos);
+
+      sink->current_pos = sink->buffer_size = sink->buffer_pos = bytes_read;
+
+      if (bytes_read != new_pos) {
+        GST_WARNING_OBJECT(sink, "Failed to preload %ld bytes, only read %ld", new_pos, bytes_read);
+      }
+    }
+  }
+
+  while (sink->current_pos < new_offset)
+  {
+    bytes_to_zero =
+        MIN(sink->config.buffer_size - sink->buffer_size,
+        new_offset - sink->current_pos);
+    memset(sink->buffer + sink->buffer_pos, 0, bytes_to_zero);
+    sink->buffer_size += bytes_to_zero;
+    sink->buffer_pos += bytes_to_zero;
+    if (sink->buffer_size == sink->config.buffer_size) {
+      if (!gst_s3_sink_flush_buffer (sink)) {
+        return FALSE;
+      }
+    }
+    sink->current_pos += bytes_to_zero;
+    sink->upload_size = MAX(sink->upload_size, sink->current_pos);
+  }
+
+  return TRUE;
+
+  /* ERRORS */
+flush_failed:
+  {
+    GST_ERROR_OBJECT (sink, "Flush failed");
+    return FALSE;
+  }
+upload_copy_failed:
+  {
+    GST_ERROR_OBJECT (sink, "Upload copy failed");
     return FALSE;
   }
 }

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -797,7 +797,7 @@ gst_s3_sink_do_flush (GstS3Sink * sink)
           sink->config.bucket,
           sink->config.key,
           sink->current_pos,
-          sink->upload_size
+          sink->upload_size - 1
         );
       }
     }
@@ -849,7 +849,7 @@ gst_s3_sink_do_seek (GstS3Sink * sink, guint64 new_offset)
         sink->config.bucket,
         sink->config.key,
         0,
-        new_pos
+        new_pos - 1
       );
 
       if (!res) {

--- a/src/gsts3sink.h
+++ b/src/gsts3sink.h
@@ -23,6 +23,7 @@
 #include <gst/base/gstbasesink.h>
 
 #include "gsts3uploader.h"
+#include "gsts3downloader.h"
 #include "gstawscredentials.h"
 
 G_BEGIN_DECLS
@@ -53,10 +54,18 @@ struct _GstS3Sink {
   GstS3UploaderConfig config;
 
   GstS3Uploader *uploader;
+  GstS3Downloader *downloader;
+
+  // Current position within the upload
+  gsize current_pos;
+  // Total accumulated data in the upload
+  gsize upload_size;
 
   gchar *buffer;
-  gsize current_buffer_size;
-  gsize total_bytes_written;
+  // Current position within buffer
+  gsize buffer_pos;
+  // Total accumulated size of data in the buffer
+  gsize buffer_size;
 
   gboolean is_started;
 };

--- a/src/gsts3uploader.c
+++ b/src/gsts3uploader.c
@@ -16,6 +16,13 @@ gst_s3_uploader_upload_part (GstS3Uploader * uploader,
 }
 
 gboolean
+gst_s3_uploader_upload_part_copy (GstS3Uploader * uploader,
+  const gchar * bucket, const gchar * key, gsize first, gsize last)
+{
+  return GET_CLASS_ (uploader)->upload_part_copy (uploader, bucket, key, first, last);
+}
+
+gboolean
 gst_s3_uploader_complete (GstS3Uploader * uploader)
 {
   return GET_CLASS_ (uploader)->complete (uploader);

--- a/src/gsts3uploader.h
+++ b/src/gsts3uploader.h
@@ -30,6 +30,7 @@ typedef struct _GstS3Uploader GstS3Uploader;
 typedef struct {
   void (*destroy) (GstS3Uploader *);
   gboolean (*upload_part) (GstS3Uploader *, const gchar *, gsize);
+  gboolean (*upload_part_copy) (GstS3Uploader *, const gchar *, const gchar *, gsize, gsize);
   gboolean (*complete) (GstS3Uploader *);
 } GstS3UploaderClass;
 
@@ -43,6 +44,9 @@ void gst_s3_uploader_destroy (GstS3Uploader * uploader);
 
 gboolean gst_s3_uploader_upload_part (GstS3Uploader *
     uploader, const gchar * buffer, gsize size);
+
+gboolean gst_s3_uploader_upload_part_copy (GstS3Uploader *
+    uploader, const gchar * bucket, const gchar * key, gsize first, gsize last);
 
 gboolean gst_s3_uploader_complete (GstS3Uploader * uploader);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,8 +9,17 @@ gst_s3_public_headers = [
   'gstawscredentials.hpp'
 ]
 
+aws_utils = static_library('awsutils', [
+    'gstawsapihandle.cpp',
+    'gstawsutils.cpp'
+  ],
+  dependencies : [aws_cpp_sdk_s3_dep, gst_dep],
+  install : false
+)
+
 credentials = library('gstawscredentials-@0@'.format(apiversion),
   ['gstawscredentials.cpp'],
+  link_with: aws_utils,
   dependencies : [aws_cpp_sdk_sts_dep, gst_dep],
   install : true
 )
@@ -19,11 +28,18 @@ credentials_dep = declare_dependency(link_with : credentials,
   include_directories : [include_directories('.')]
 )
 
+downloader = static_library('downloader', [
+    'gsts3downloader.cpp'
+  ],
+  link_with : aws_utils,
+  dependencies : [aws_cpp_sdk_s3_dep, gst_dep],
+  install : false
+)
+
 multipart_uploader = static_library('multipartuploader', [
-    'gstawsapihandle.cpp',
-    'gsts3downloader.cpp',
     'gsts3multipartuploader.cpp'
   ],
+  link_with: [aws_utils, downloader],
   dependencies : [aws_cpp_sdk_s3_dep, gst_dep],
   install : false
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,8 +19,11 @@ credentials_dep = declare_dependency(link_with : credentials,
   include_directories : [include_directories('.')]
 )
 
-multipart_uploader = static_library('multipartuploader',
-  ['gsts3multipartuploader.cpp'],
+multipart_uploader = static_library('multipartuploader', [
+    'gstawsapihandle.cpp',
+    'gsts3downloader.cpp',
+    'gsts3multipartuploader.cpp'
+  ],
   dependencies : [aws_cpp_sdk_s3_dep, gst_dep],
   install : false
 )

--- a/tests/check/s3sink.c
+++ b/tests/check/s3sink.c
@@ -58,6 +58,21 @@ test_uploader_upload_part (GstS3Uploader * uploader, G_GNUC_UNUSED const gchar *
 }
 
 static gboolean
+test_uploader_upload_part_copy (GstS3Uploader * uploader, G_GNUC_UNUSED const gchar * bucket,
+  G_GNUC_UNUSED const gchar * key, G_GNUC_UNUSED gsize first, G_GNUC_UNUSED gsize last)
+{
+  gboolean ok = TEST_UPLOADER(uploader)->fail_upload_retry != 0;
+
+  TEST_UPLOADER(uploader)->upload_part_count++;
+
+  if (ok) {
+    TEST_UPLOADER(uploader)->fail_upload_retry--;
+  }
+
+  return ok;
+}
+
+static gboolean
 test_uploader_complete (GstS3Uploader * uploader)
 {
   return !TEST_UPLOADER(uploader)->fail_complete;
@@ -66,6 +81,7 @@ test_uploader_complete (GstS3Uploader * uploader)
 static GstS3UploaderClass test_uploader_class = {
   test_uploader_destroy,
   test_uploader_upload_part,
+  test_uploader_upload_part_copy,
   test_uploader_complete
 };
 


### PR DESCRIPTION
*Issue #, if available:* VIDEO-1728

*Description of changes:*
* Moves API handle to it's own header for re-use
* Adds `aws-s3` logging category for API logging
* Adds support for seeking in S3 sink, optimized with copy-uploading

To test run:
```
GST_DEBUG=*:3,s3sink:7 gst-launch-1.0 videotestsrc pattern=snow num-buffers=2100 ! video/x-raw,width=1280,height=720,framerate=30/1 ! x264enc ! video/x-h264,profile=constrained-baseline ! mp4mux ! s3sink bucket=dev-laerdallabs-vera-recordings key=test.mp4
```
You'll see something like this in the logs:
```
0:00:06.829771200   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:688:gst_s3_sink_flush_buffer:<s3sink0> Uploading 5242880 byte part
0:00:15.227416800   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:688:gst_s3_sink_flush_buffer:<s3sink0> Uploading 5242880 byte part
0:00:23.474965300   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:688:gst_s3_sink_flush_buffer:<s3sink0> Uploading 5242880 byte part
0:00:24.407088000   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:820:gst_s3_sink_do_seek:<s3sink0> Seeking to new offset 32 from 16563157 of 16563157 total bytes
0:00:24.407151100   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:743:gst_s3_sink_do_flush:<s3sink0> Flushing S3 Upload
0:00:24.407238600   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:688:gst_s3_sink_flush_buffer:<s3sink0> Uploading 834517 byte part
...
0:00:24.956218200   519 0x555c890e4980 TRACE                 s3sink gsts3sink.c:862:gst_s3_sink_do_seek:<s3sink0> Seeking to offset 32 by downloading
0:00:25.046026200   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:743:gst_s3_sink_do_flush:<s3sink0> Flushing S3 Upload
0:00:25.046117300   519 0x555c890e4980 TRACE                 s3sink gsts3sink.c:754:gst_s3_sink_do_flush:<s3sink0> Post-filling 5242832 bytes, range: 48-5242880
0:00:25.235402600   519 0x555c890e4980 DEBUG                 s3sink gsts3sink.c:688:gst_s3_sink_flush_buffer:<s3sink0> Uploading 5242880 byte part
0:00:25.236415100   519 0x555c890e4980 TRACE                 s3sink gsts3sink.c:794:gst_s3_sink_do_flush:<s3sink0> Copy-uploading remaining file from 5242880 to 16563157
```
Here it's uploading 3 5MB chunks, gets a seek to new offset (`32`) which causes it to upload the current/last `834517` bytes then complete the upload. Then it does the actual seek by downloading the first `32` bytes, receives more data (not logged), "post-fills" the rest of the data in the 5MB chunk, uploads the updated 5MB chunk, then copy-uploads (which is performed _in_ S3) the remaining data, and completes the upload.

The resulting file in S3 should be playable.