### PR TITLE
[VIDEO-1902] gsts3downloader does not handle 'location' in config

### DIFF
--- a/src/gstawsutils.cpp
+++ b/src/gstawsutils.cpp
@@ -41,3 +41,32 @@ bool is_null_or_empty(const char* str)
 {
   return str == nullptr || strcmp(str, "") == 0;
 }
+
+const Aws::String get_bucket_from_config(const GstS3UploaderConfig * config)
+{
+    if (is_null_or_empty(config->location)) {
+        return config->bucket;
+    } else {
+        GstUri *uri = gst_uri_from_string(config->location);
+        Aws::String bucket(gst_uri_get_host(uri));
+        gst_uri_unref(uri);
+        return bucket;
+    }
+}
+
+const Aws::String get_key_from_config(const GstS3UploaderConfig * config)
+{
+    if (is_null_or_empty(config->location)) {
+        return config->key;
+    } else {
+        GstUri *uri = gst_uri_from_string(config->location);
+        Aws::String path(gst_uri_get_path(uri));
+        gst_uri_unref(uri);
+
+        if (path[0] == '/') {
+            return path.substr(1);
+        } else {
+            return path;
+        }
+    }
+}

--- a/src/gstawsutils.hpp
+++ b/src/gstawsutils.hpp
@@ -22,10 +22,16 @@
 
 #include <aws/core/client/ClientConfiguration.h>
 
+#include "gsts3uploaderconfig.h"
+
 bool get_bucket_location   (const char* bucket_name,
                             const Aws::Client::ClientConfiguration& client_config,
                             Aws::String& location);
 
 bool is_null_or_empty  (const char* str);
+
+const Aws::String get_bucket_from_config(const GstS3UploaderConfig * config);
+
+const Aws::String get_key_from_config(const GstS3UploaderConfig * config);
 
 #endif // __GST_AWS_UTILS_HPP__

--- a/src/gsts3downloader.cpp
+++ b/src/gsts3downloader.cpp
@@ -42,8 +42,8 @@ struct _GstS3Downloader {
 };
 
 _GstS3Downloader::_GstS3Downloader(const GstS3UploaderConfig *config) :
-    _bucket(config->bucket),
-    _key(config->key),
+    _bucket(std::move(get_bucket_from_config(config))),
+    _key(std::move(get_key_from_config(config))),
     _api_handle(config->init_aws_sdk ? gst::aws::AwsApiHandle::GetHandle() : nullptr)
 {
 }

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -48,35 +48,6 @@ namespace aws
 namespace s3
 {
 
-static const Aws::String get_bucket_from_config(const GstS3UploaderConfig * config)
-{
-    if (is_null_or_empty(config->location)) {
-        return config->bucket;
-    } else {
-        GstUri *uri = gst_uri_from_string(config->location);
-        Aws::String bucket(gst_uri_get_host(uri));
-        gst_uri_unref(uri);
-        return bucket;
-    }
-}
-
-static const Aws::String get_key_from_config(const GstS3UploaderConfig * config)
-{
-    if (is_null_or_empty(config->location)) {
-        return config->key;
-    } else {
-        GstUri *uri = gst_uri_from_string(config->location);
-        Aws::String path(gst_uri_get_path(uri));
-        gst_uri_unref(uri);
-
-        if (path[0] == '/') {
-            return path.substr(1);
-        } else {
-            return path;
-        }
-    }
-}
-
 using BufferManager = Aws::Utils::ExclusiveOwnershipResourceManager<uint8_t*>;
 
 class PartState


### PR DESCRIPTION
VIDEO-1902: gsts3downloader class does not support 'location' property

*Description of changes:*

1. Moved the utility function out of mulitpart uploader which was responsible for handling a config containing `bucket+key` vs. `location` into the `gstawsutils` utility function file to make each accessible to the downloader as well.
2. Refactored the downloader to utilize the functions in (1) similar to the multipart uploader.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
