### PR TITLE
[VIDEO-2517] Fix Uploader Race Condition

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ if host_system == 'windows'
   cpp_args = ['/std:c++20']
 else
   c_args = ['-std=c17']
-  cpp_args = ['-std=c++17']
+  cpp_args = ['-std=c++17', '-fexceptions']
 endif
 
 apiversion = '1.0'


### PR DESCRIPTION
*Issue #, if available:*
VIDEO-2517

*Description of changes:*
Made changes to fix a race condition in the uploader that can happen if multiple parts are being uploaded on different threads and the sink EOS causes an upload completion attempt. Also added exception handling to trap for the possible exception if
the race condition results in clearing part tracking state before the last in flight part is completed.

