### PR TITLE
Clean up nuget build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,7 +2,8 @@ name: Laerdal Labs, DC GStreamer Plugin Windows Build
 on:
   push:
     branches: [ master ]
-    tags: [ 'v*' ]
+  release:
+    types: [released, published]
   pull_request:
     branches: [ master ]
   workflow_dispatch:
@@ -27,7 +28,7 @@ jobs:
         uses: NuGet/setup-nuget@v1
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v1
 
       - name: Setup VS Dev Environment
         uses: seanmiddleditch/gha-setup-vsdevenv@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,15 +24,6 @@ jobs:
       - name: Install meson/ninja
         run: pip install meson ninja
 
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
-
-      - name: Setup VS Dev Environment
-        uses: seanmiddleditch/gha-setup-vsdevenv@v4
-
       - name: Install GStreamer
         id: setup_gstreamer
         uses: blinemedical/setup-gstreamer@v1
@@ -57,6 +48,9 @@ jobs:
           meson setup --vsenv build
           echo "plugin_version=$((meson introspect --projectinfo build | ConvertFrom-Json).version)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
           meson compile -C build
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
 
       - name: Generate NuGet packages
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,14 +11,9 @@ jobs:
   build-package:
     name: Build Windows Nuget Package
     runs-on: windows-2022
-    defaults:
-      run:
-        working-directory: aws-s3-gst-plugin
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          path: aws-s3-gst-plugin 
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -49,16 +44,16 @@ jobs:
           chcp 65001 #set code page to utf-8
           echo ("GSTREAMER_1_0_ROOT_MSVC_X86_64=${{ steps.setup_gstreamer.outputs.gstreamerPath }}") >> $env:GITHUB_ENV
           echo ("${{ steps.setup_gstreamer.outputs.gstreamerPath }}\bin") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      
+
       - name: Clone Aws-SDK
         uses: actions/checkout@v2
         with:
           repository: blinemedical/aws-sdk-cpp
           submodules: recursive
           path: ./aws-sdk-cpp
-      
+
       - name: Build bline/aws-sdk-cpp
-        run: | 
+        run: |
           cd D:\a\amazon-s3-gst-plugin\amazon-s3-gst-plugin\aws-sdk-cpp
           cmake  -S . -B build -G "Visual Studio 17 2022" -DBUILD_ONLY="s3;sts" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=C:/aws-cpp-sdk-all
           cmake --build build -j --config Debug
@@ -74,11 +69,10 @@ jobs:
         run: |
             mkdir nupkgs
             nuget.exe pack amazon-s3-gst-plugin.nuspec -OutputDirectory nupkgs
-      
+
       - name: Publish
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
             Get-ChildItem ./nupkgs -filter "*.nupkg" | foreach{
               dotnet nuget push $_.FullName --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/blinemedical/index.json
             }
-        

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build Amazon-S3 Plugin
         run: |
-          meson setup --vsenv --buildtype debug --pkg-config-path C:/aws-cpp-sdk-all/lib/pkgconfig build
+          meson setup --vsenv --pkg-config-path C:/aws-cpp-sdk-all/lib/pkgconfig build
           meson compile -C build
 
       - name: Generate NuGet packages

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,23 +46,20 @@ jobs:
           echo ("GSTREAMER_1_0_ROOT_MSVC_X86_64=${{ steps.setup_gstreamer.outputs.gstreamerPath }}") >> $env:GITHUB_ENV
           echo ("${{ steps.setup_gstreamer.outputs.gstreamerPath }}\bin") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Clone Aws-SDK
-        uses: actions/checkout@v2
+      - uses: actions/github-script@v6
         with:
-          repository: blinemedical/aws-sdk-cpp
-          submodules: recursive
-          path: ./aws-sdk-cpp
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Build bline/aws-sdk-cpp
+      - name: Install AWS C++ SDK
         run: |
-          cd D:\a\amazon-s3-gst-plugin\amazon-s3-gst-plugin\aws-sdk-cpp
-          cmake  -S . -B build -G "Visual Studio 17 2022" -DBUILD_ONLY="s3;sts" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=C:/aws-cpp-sdk-all
-          cmake --build build -j --config Debug
-          cmake --install build --config Debug
+          vcpkg install aws-sdk-cpp[s3,sts] --binarysource="clear;x-gha,readwrite"
+          echo "CMAKE_PREFIX_PATH=$Env:VCPKG_INSTALLATION_ROOT\installed\x64-windows" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Build Amazon-S3 Plugin
         run: |
-          meson setup --vsenv --pkg-config-path C:/aws-cpp-sdk-all/lib/pkgconfig build
+          meson setup --vsenv build
           meson compile -C build
 
       - name: Generate NuGet packages

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,7 +37,7 @@ jobs:
         id: setup_gstreamer
         uses: blinemedical/setup-gstreamer@v1.1.0
         with:
-          version: '1.22.4'
+          version: '1.22.7'
           arch: 'x86_64'
 
       - name: Add GStreamer to the environment/path (Windows)

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,15 +58,16 @@ jobs:
           echo "CMAKE_PREFIX_PATH=$Env:VCPKG_INSTALLATION_ROOT\installed\x64-windows" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Build Amazon-S3 Plugin
+        id: build_plugin
         run: |
           meson setup --vsenv build
+          echo "plugin_version=$((meson introspect --projectinfo build | ConvertFrom-Json).version)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
           meson compile -C build
 
       - name: Generate NuGet packages
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
             mkdir nupkgs
-            nuget.exe pack amazon-s3-gst-plugin.nuspec -OutputDirectory nupkgs
+            nuget.exe pack amazon-s3-gst-plugin.nuspec -Version ${{ steps.build_plugin.outputs.plugin_version }}.${{ github.run_number }} -OutputDirectory nupkgs
 
       - name: Publish
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,16 +35,10 @@ jobs:
 
       - name: Install GStreamer
         id: setup_gstreamer
-        uses: blinemedical/setup-gstreamer@v1.1.0
+        uses: blinemedical/setup-gstreamer@v1
         with:
           version: '1.22.7'
           arch: 'x86_64'
-
-      - name: Add GStreamer to the environment/path (Windows)
-        run: |
-          chcp 65001 #set code page to utf-8
-          echo ("GSTREAMER_1_0_ROOT_MSVC_X86_64=${{ steps.setup_gstreamer.outputs.gstreamerPath }}") >> $env:GITHUB_ENV
-          echo ("${{ steps.setup_gstreamer.outputs.gstreamerPath }}\bin") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - uses: actions/github-script@v6
         with:

--- a/amazon-s3-gst-plugin.nuspec
+++ b/amazon-s3-gst-plugin.nuspec
@@ -2,7 +2,7 @@
 <package >
     <metadata>
         <id>Amazon-S3-Plugin</id>
-        <version>0.2.0</version>
+        <version>$version$</version>
         <description>Amazon Gstreamer S3 Plugin</description>
         <authors> Thomas Goodwin, Lyra McMillan, Jeff Wilson, Sara Boule</authors>
         <tags>Native, native</tags>


### PR DESCRIPTION
Tons of improvements when building the nuget packages:
* Switch to using `vcpkg` for building the AWS C++ SDK (instead of our fork, which we can probably now kill)
* Set the Nuget Package version dynamically
* Fixed the build by using the latest `setup-gstreamer`
* A bunch of other cleanup and fixes