### PR TITLE
Add a Null Check in GstS3Downloader Destructor

### DIFF
--- a/src/gsts3downloader.cpp
+++ b/src/gsts3downloader.cpp
@@ -158,7 +158,8 @@ struct _GstS3DefaultDownloader
 static void
 gst_s3_default_downloader_destroy (GstS3Downloader *downloader)
 {
-  delete DOWNLOADER_(downloader);
+  if (downloader)
+    delete DOWNLOADER_(downloader);
 }
 
 static size_t


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I was having issues with multiple s3sinks in Video-2183, and the downloader destuctor getting called multiple times, but it had been subsequently been deleted. Simply adding a null check fixes this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
