### PR TITLE
[Video-2649] Don't Release Empty Buffers

### DIFF
--- a/src/gstawscredentials.cpp
+++ b/src/gstawscredentials.cpp
@@ -29,6 +29,8 @@ GST_DEBUG_CATEGORY_STATIC (gst_aws_credentials_debug);
 
 using namespace Aws::Auth;
 
+static GstAWSCredentials * _gst_aws_credentials_from_string (const gchar * str);
+
 struct _GstAWSCredentials {
   _GstAWSCredentials(GstAWSCredentialsProviderFactory factory) :
     credentials_provider_factory(std::move(factory))
@@ -71,9 +73,10 @@ gst_aws_credentials_free (GstAWSCredentials * credentials)
 }
 
 GstAWSCredentials *
-gst_aws_credentials_new_from_string(const gchar * str)
+gst_aws_credentials_new_from_string(const gchar * s)
 {
-  return _gst_aws_credentials_from_string (str);
+ // gst_aws_credentials_new_default();
+  return _gst_aws_credentials_from_string (s);
 }
 
 

--- a/src/gstawscredentials.cpp
+++ b/src/gstawscredentials.cpp
@@ -70,6 +70,13 @@ gst_aws_credentials_free (GstAWSCredentials * credentials)
   delete credentials;
 }
 
+GstAWSCredentials *
+gst_aws_credentials_new_from_string(const gchar * str)
+{
+  return _gst_aws_credentials_from_string (str);
+}
+
+
 static bool
 strings_equal(const gchar* str1, const gchar* str2, size_t len2)
 {

--- a/src/gstawscredentials.h
+++ b/src/gstawscredentials.h
@@ -40,6 +40,11 @@ GstAWSCredentials * gst_aws_credentials_from_string (const gchar * str);
 GST_EXPORT
 GType gst_aws_credentials_get_type (void);
 
+GST_EXPORT
+GstAWSCredentials * gst_aws_credentials_new_from_string(const gchar * str);
+
+static GstAWSCredentials * _gst_aws_credentials_from_string (const gchar * str);
+
 #define GST_TYPE_AWS_CREDENTIALS \
   (gst_aws_credentials_get_type())
 

--- a/src/gstawscredentials.h
+++ b/src/gstawscredentials.h
@@ -48,6 +48,4 @@ GstAWSCredentials * gst_aws_credentials_new_from_string(const gchar * str);
 
 G_END_DECLS
 
-static GstAWSCredentials * _gst_aws_credentials_from_string (const gchar * str);
-
 #endif /* __GST_AWS_CREDENTIALS_H__ */

--- a/src/gstawscredentials.h
+++ b/src/gstawscredentials.h
@@ -43,11 +43,11 @@ GType gst_aws_credentials_get_type (void);
 GST_EXPORT
 GstAWSCredentials * gst_aws_credentials_new_from_string(const gchar * str);
 
-static GstAWSCredentials * _gst_aws_credentials_from_string (const gchar * str);
-
 #define GST_TYPE_AWS_CREDENTIALS \
   (gst_aws_credentials_get_type())
 
 G_END_DECLS
+
+static GstAWSCredentials * _gst_aws_credentials_from_string (const gchar * str);
 
 #endif /* __GST_AWS_CREDENTIALS_H__ */

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -226,7 +226,7 @@ gst_s3_sink_class_init (GstS3SinkClass * klass)
   g_object_class_install_property (gobject_class, PROP_CREDENTIALS_STRING,
     g_param_spec_string("aws-credentials-string", "AWS credentials (string)",
       "The AWS credentials to use parsed from string", NULL,
-      G_PARAM_WRITABLE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
+      G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_AWS_SDK_ENDPOINT,
     g_param_spec_string ("aws-sdk-endpoint", "AWS SDK Endpoint",
@@ -427,7 +427,8 @@ gst_s3_sink_set_property (GObject * object, guint prop_id,
     case PROP_CREDENTIALS_STRING:
       if (sink->config.credentials)
         gst_aws_credentials_free (sink->config.credentials);
-      sink->config.credentials = gst_aws_credentials_new_from_string(g_value_get_string (value));
+      gst_s3_sink_set_string_property (sink, g_value_get_string (value), &sink->credentials_string, "aws-credentials-string");
+      sink->config.credentials = gst_aws_credentials_new_from_string(sink->credentials_string);
       break;
     case PROP_AWS_SDK_ENDPOINT:
       gst_s3_sink_set_string_property (sink, g_value_get_string (value),
@@ -523,7 +524,7 @@ gst_s3_sink_get_property (GObject * object, guint prop_id, GValue * value,
       g_value_set_int (value, sink->config.cache_num_parts);
       break;
     case PROP_CREDENTIALS_STRING:
-    //  g_value_set_string (value, sink->config.region);
+      g_value_set_string (value, sink->credentials_string);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -224,8 +224,8 @@ gst_s3_sink_class_init (GstS3SinkClass * klass)
       G_PARAM_WRITABLE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
   
   g_object_class_install_property (gobject_class, PROP_CREDENTIALS_STRING,
-    g_param_spec_string("aws-credentials-string", "AWS credentials",
-      "The AWS credentials to use", NULL,
+    g_param_spec_string("aws-credentials-string", "AWS credentials (string)",
+      "The AWS credentials to use parsed from string", NULL,
       G_PARAM_WRITABLE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_AWS_SDK_ENDPOINT,
@@ -521,6 +521,9 @@ gst_s3_sink_get_property (GObject * object, guint prop_id, GValue * value,
       break;
     case PROP_NUM_CACHE_PARTS:
       g_value_set_int (value, sink->config.cache_num_parts);
+      break;
+    case PROP_CREDENTIALS_STRING:
+    //  g_value_set_string (value, sink->config.region);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -74,6 +74,7 @@ enum
   PROP_BUFFER_SIZE,
   PROP_INIT_AWS_SDK,
   PROP_CREDENTIALS,
+  PROP_CREDENTIALS_STRING,
   PROP_AWS_SDK_ENDPOINT,
   PROP_AWS_SDK_USE_HTTP,
   PROP_AWS_SDK_VERIFY_SSL,
@@ -220,6 +221,11 @@ gst_s3_sink_class_init (GstS3SinkClass * klass)
   g_object_class_install_property (gobject_class, PROP_CREDENTIALS,
     g_param_spec_boxed ("aws-credentials", "AWS credentials",
       "The AWS credentials to use", GST_TYPE_AWS_CREDENTIALS,
+      G_PARAM_WRITABLE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
+  
+  g_object_class_install_property (gobject_class, PROP_CREDENTIALS_STRING,
+    g_param_spec_string("aws-credentials-string", "AWS credentials",
+      "The AWS credentials to use", NULL,
       G_PARAM_WRITABLE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_AWS_SDK_ENDPOINT,
@@ -417,6 +423,11 @@ gst_s3_sink_set_property (GObject * object, guint prop_id,
       if (sink->config.credentials)
         gst_aws_credentials_free (sink->config.credentials);
       sink->config.credentials = gst_aws_credentials_copy (g_value_get_boxed (value));
+      break;
+    case PROP_CREDENTIALS_STRING:
+      if (sink->config.credentials)
+        gst_aws_credentials_free (sink->config.credentials);
+      sink->config.credentials = gst_aws_credentials_new_from_string(g_value_get_string (value));
       break;
     case PROP_AWS_SDK_ENDPOINT:
       gst_s3_sink_set_string_property (sink, g_value_get_string (value),

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -972,7 +972,8 @@ gst_s3_sink_do_seek (GstS3Sink * sink, guint64 new_offset)
         goto cache_failed;
 
       memcpy(sink->buffer, next, next_size);
-      g_free(next);
+      if (*next)
+        g_free(next);
 
       // Assumption here is all preceding buffers, if they exist,
       // are the same size as the config states.

--- a/src/gsts3sink.h
+++ b/src/gsts3sink.h
@@ -81,6 +81,8 @@ struct _GstS3Sink {
   // doing any download/copy-upload -like operations
   // that would require the uploader to 'complete'
   gboolean uploader_needs_complete;
+
+  gchar * credentials_string;
 };
 
 struct _GstS3SinkClass {

--- a/tests/check/s3sink.c
+++ b/tests/check/s3sink.c
@@ -89,16 +89,22 @@ GST_END_TEST
 GST_START_TEST (test_credentials_property)
 {
   GstElement *sink = gst_element_factory_make ("s3sink", "sink");
-  GstAWSCredentials *credentials = gst_aws_credentials_from_string ("access-key-id=someAccessKey|secret-access-key=someAccessSecret");
+  const gchar *location = "s3://bucket/key";
+
+  gchar *returned_credentials = NULL;
+  gchar * credentialstr = "access-key-id=someAccessKey";
 
   fail_if (sink == NULL);
 
+  // Set location, then set bucket and key, verify location is used
+  g_object_set (sink, "aws-credentials-string", "access-key-id=someAccessKey", NULL);
   g_object_set (sink,
-    "aws-credentials",
-    credentials,
+    "bucket", "new-bucket",
+    "key", "new-key",
     NULL);
-
-  gst_aws_credentials_free (credentials);
+  g_object_get (sink, "aws-credentials-string", &returned_credentials, NULL);
+  fail_if (0 != g_ascii_strcasecmp("access-key-id=someAccessKey", returned_credentials));
+  g_free (returned_credentials);
 
   gst_object_unref (sink);
 }


### PR DESCRIPTION
*Issue #, if available:*
[Video-2649] 
This is just adding some defensive programming in checking to make sure a buffer is not empty before releasing it. Somewhere else (most likely in the MultipartUploader) is releasing the buffer before we actually get to use it here. This check seems to get me where I need to be with the element for now as it will still upload the file in whole to s3. However, we still will want to investigate the why of this issue as well. 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
