### PR TITLE
[Video-2649] Don't Release Empty Buffers

### DIFF
--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -957,7 +957,8 @@ gst_s3_sink_do_seek (GstS3Sink * sink, guint64 new_offset)
         goto cache_failed;
 
       memcpy(sink->buffer, next, next_size);
-      g_free(next);
+      if (*next)
+        g_free(next);
 
       // Assumption here is all preceding buffers, if they exist,
       // are the same size as the config states.


### PR DESCRIPTION
[[Video-2649](https://blinemedical.atlassian.net/browse/VIDEO-2649)]
This is just adding some defensive programming in checking to make sure a buffer is not empty before releasing it. Somewhere else (most likely in the MultipartUploader) is releasing the buffer before we actually get to use it here. This check seems to get me where I need to be with the element for now as it will still upload the file in whole to s3. However, we still will want to investigate the why of this issue as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
