### PR TITLE
Fix compiler warning about mismatched allocator.

### DIFF
--- a/src/gsts3uploaderpartcache.hpp
+++ b/src/gsts3uploaderpartcache.hpp
@@ -190,7 +190,7 @@ public:
 
         void clear_buffer() {
             if (_buffer) {
-                free(_buffer);
+                delete [] _buffer;
             }
             _buffer = NULL;
         }

--- a/tests/check/uploaderpartcache.cpp
+++ b/tests/check/uploaderpartcache.cpp
@@ -24,7 +24,7 @@
 using gst::aws::s3::UploaderPartCache;
 
 #define TEST_BUFFER_NEW(s) (new char[s])
-#define TEST_BUFFER_FREE(b) {if (b) free(b); b = NULL;}
+#define TEST_BUFFER_FREE(b) {if (b) delete [] b; b = NULL;}
 
 GST_START_TEST(test_part_info) {
   UploaderPartCache::PartInfo uut;


### PR DESCRIPTION
The patched lines of code here used `free` to deallocate memory created with `new` when the author _\<ahem\>_ should have used `delete`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
