### PR TITLE
Set VERSION to GStreamer Core Version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ configinc = include_directories('.')
 plugins_install_dir = join_paths(get_option('libdir'), 'gstreamer-1.0')
 
 core_conf = configuration_data()
-core_conf.set_quoted('VERSION', gst_s3_version)
+core_conf.set_quoted('VERSION', gst_base_dep.version())
 core_conf.set_quoted('PACKAGE', 'amazon-s3-gst-plugin')
 
 configure_file(output : 'config.h', configuration : core_conf)


### PR DESCRIPTION
The documentation is very unclear about this, implying that this 'version' field of the plugin definition macro where this variable would be used is actually different (independent) from the gstreamer version.  In fact, it is seemingly supposed to be the full version string (of gstreamer core) that the plugin was compiled against, not the independent version of the plugin itself.

[Related Thread](https://discourse.gstreamer.org/t/clarification-about-gst-plugin-define/1041)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
