### PR TITLE
Bump github action workflow versions for GStreamer to 1.22.9

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,7 +28,7 @@ jobs:
         id: setup_gstreamer
         uses: blinemedical/setup-gstreamer@v1
         with:
-          version: '1.22.7'
+          version: '1.22.9'
           arch: 'x86_64'
 
       - uses: actions/github-script@v6

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,7 +18,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: blinemedical/setup-gstreamer@main
         with:
-          version: '1.22.2'
+          version: '1.22.9'
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
         run: >-


### PR DESCRIPTION
Other PRs are on 1.22.2 and failing because of some lib soup lookup dependency.  I'm bumping the version to latest in case there's something to this version that's now broken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
