### PR TITLE
[VIDEO-3153] Update GStreamer in Windows build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,7 @@ jobs:
         name: Get GStreamer
         uses: blinemedical/cerbero/.github/actions/build-gstreamer-for-windows@1.24-lldc
         with:
-          cerbero-ref: 1.24.8-lldc
+          cerbero-ref: 1.24.8-lldc.2
           cerbero-args: --clocktime --timestamps -v visualstudio,noasserts
           s3-download-paths: ${{ vars.GSTREAMER_S3_DOWNLOAD_PATH }}
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('amazon-s3-gst-plugin', 'c', 'cpp',
-  version : '0.2.1-lldc.11',
+  version : '0.2.1-lldc.12',
   default_options : [ 'warning_level=2',
                       'buildtype=debugoptimized' ])
 


### PR DESCRIPTION
- Bumps GStreamer version to `1.24.8-lldc.2` when building Windows NuGet packages
- Bumps project version to `0.2.1-lldc.12`
- Builds on updated self-hosted runners with VS `17.12.3`